### PR TITLE
Fix typo in entity creation command type

### DIFF
--- a/packages/core/src/domain/common/base.entity.ts
+++ b/packages/core/src/domain/common/base.entity.ts
@@ -39,12 +39,12 @@ export class BaseEntity {
     }
   }
 
-  static create(_entity: CreatEntityCommand<BaseEntity>): BaseEntity {
+  static create(_entity: CreateEntityCommand<BaseEntity>): BaseEntity {
     throw new Error('Method not implemented.');
   }
 }
 
-export type CreatEntityCommand<Entity extends BaseEntity> = Omit<
+export type CreateEntityCommand<Entity extends BaseEntity> = Omit<
   Entity,
   'id' | 'createdAt' | 'updatedAt' | 'validate'
 > &
@@ -52,7 +52,7 @@ export type CreatEntityCommand<Entity extends BaseEntity> = Omit<
 
 export const addBaseFields = <Entity extends BaseEntity>(
   entity: Entity,
-  command: CreatEntityCommand<Entity>,
+  command: CreateEntityCommand<Entity>,
 ) => {
   if (command.id) {
     entity.id = command.id;

--- a/packages/core/src/domain/entities/collection-fork.entity.ts
+++ b/packages/core/src/domain/entities/collection-fork.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 
@@ -17,7 +17,7 @@ export class CollectionForkEntity extends BaseEntity {
   @ZodValidator(z.string())
   forkedId: string;
 
-  static create(command: CreatEntityCommand<CollectionForkEntity>) {
+  static create(command: CreateEntityCommand<CollectionForkEntity>) {
     const entity = new CollectionForkEntity();
 
     entity.userId = command.userId;

--- a/packages/core/src/domain/entities/collection-hierarchy.entity.ts
+++ b/packages/core/src/domain/entities/collection-hierarchy.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 
@@ -17,7 +17,7 @@ export class CollectionHierarchyEntity extends BaseEntity {
   @ZodValidator(z.string())
   childId: string;
 
-  static create(command: CreatEntityCommand<CollectionHierarchyEntity>) {
+  static create(command: CreateEntityCommand<CollectionHierarchyEntity>) {
     const entity = new CollectionHierarchyEntity();
 
     entity.userId = command.userId;

--- a/packages/core/src/domain/entities/collection-item.entity.ts
+++ b/packages/core/src/domain/entities/collection-item.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 import { JsonVo } from '@/domain/value-objects/json.vo';
@@ -20,7 +20,7 @@ export class CollectionItemEntity extends BaseEntity {
 
   jsonFields: JsonVo;
 
-  static create(command: CreatEntityCommand<CollectionItemEntity>) {
+  static create(command: CreateEntityCommand<CollectionItemEntity>) {
     const entity = new CollectionItemEntity();
 
     entity.jsonFields = command.jsonFields;

--- a/packages/core/src/domain/entities/collection.entity.ts
+++ b/packages/core/src/domain/entities/collection.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 import { JsonVo } from '@/domain/value-objects/json.vo';
@@ -20,7 +20,7 @@ export class CollectionEntity extends BaseEntity {
   @ZodValidator(z.number())
   version: number;
 
-  static create(command: CreatEntityCommand<CollectionEntity>) {
+  static create(command: CreateEntityCommand<CollectionEntity>) {
     const entity = new CollectionEntity();
 
     entity.jsonSchema = command.jsonSchema;

--- a/packages/core/src/domain/entities/password.entity.ts
+++ b/packages/core/src/domain/entities/password.entity.ts
@@ -1,7 +1,7 @@
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { UserEntity } from '@/domain/entities/user.entity';
 import { PasswordVo } from '@/domain/value-objects/password.vo';
@@ -11,7 +11,7 @@ export class PasswordEntity extends BaseEntity {
 
   user: UserEntity;
 
-  static create(command: CreatEntityCommand<PasswordEntity>) {
+  static create(command: CreateEntityCommand<PasswordEntity>) {
     const entity = new PasswordEntity();
 
     entity.hash = command.hash;

--- a/packages/core/src/domain/entities/rating-system-fork.entity.ts
+++ b/packages/core/src/domain/entities/rating-system-fork.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 
@@ -23,7 +23,7 @@ export class RatingSystemForkEntity extends BaseEntity {
   @ZodValidator(z.string())
   forkedId: string;
 
-  static create(command: CreatEntityCommand<RatingSystemForkEntity>) {
+  static create(command: CreateEntityCommand<RatingSystemForkEntity>) {
     const entity = new RatingSystemForkEntity();
 
     entity.userId = command.userId;

--- a/packages/core/src/domain/entities/rating-system-hierarchy.entity.ts
+++ b/packages/core/src/domain/entities/rating-system-hierarchy.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 
@@ -17,7 +17,7 @@ export class RatingSystemHierarchyEntity extends BaseEntity {
   @ZodValidator(z.string())
   childId: string;
 
-  static create(command: CreatEntityCommand<RatingSystemHierarchyEntity>) {
+  static create(command: CreateEntityCommand<RatingSystemHierarchyEntity>) {
     const entity = new RatingSystemHierarchyEntity();
 
     entity.userId = command.userId;

--- a/packages/core/src/domain/entities/rating-system.entity.ts
+++ b/packages/core/src/domain/entities/rating-system.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 import { JsonVo } from '@/domain/value-objects/json.vo';
@@ -22,7 +22,7 @@ export class RatingSystemEntity extends BaseEntity {
 
   jsonFormula: JsonVo;
 
-  static create(command: CreatEntityCommand<RatingSystemEntity>) {
+  static create(command: CreateEntityCommand<RatingSystemEntity>) {
     const entity = new RatingSystemEntity();
 
     entity.name = command.name;

--- a/packages/core/src/domain/entities/rating.entity.ts
+++ b/packages/core/src/domain/entities/rating.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 import { JsonVo } from '@/domain/value-objects/json.vo';
@@ -20,7 +20,7 @@ export class RatingEntity extends BaseEntity {
 
   jsonRates: JsonVo;
 
-  static create(command: CreatEntityCommand<RatingEntity>) {
+  static create(command: CreateEntityCommand<RatingEntity>) {
     const entity = new RatingEntity();
 
     entity.jsonRates = command.jsonRates;

--- a/packages/core/src/domain/entities/session.entity.ts
+++ b/packages/core/src/domain/entities/session.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 
@@ -29,7 +29,7 @@ export class SessionEntity extends BaseEntity {
   @ZodValidator(z.string().optional())
   userAgent: string | null;
 
-  static create(command: CreatEntityCommand<SessionEntity>) {
+  static create(command: CreateEntityCommand<SessionEntity>) {
     const session = new SessionEntity();
 
     session.sessionId = command.sessionId;
@@ -59,7 +59,7 @@ export class TokenEntity extends BaseEntity {
 
   session: SessionEntity;
 
-  static create(command: CreatEntityCommand<TokenEntity>) {
+  static create(command: CreateEntityCommand<TokenEntity>) {
     const token = new TokenEntity();
 
     token.accessToken = command.accessToken;

--- a/packages/core/src/domain/entities/user.entity.ts
+++ b/packages/core/src/domain/entities/user.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   addBaseFields,
   BaseEntity,
-  CreatEntityCommand,
+  CreateEntityCommand,
 } from '@/domain/common/base.entity';
 import { ZodValidator } from '@/domain/common/zod-validator';
 import { EmailVo } from '@/domain/value-objects/email.vo';
@@ -28,7 +28,7 @@ export class UserEntity extends BaseEntity {
   @ZodValidator(z.nativeEnum(UserVerifiedStatus))
   verifiedStatus: UserVerifiedStatus;
 
-  static create(command: CreatEntityCommand<UserEntity>) {
+  static create(command: CreateEntityCommand<UserEntity>) {
     const user = new UserEntity();
 
     user.email = command.email;


### PR DESCRIPTION
## Summary
- fix type name `CreateEntityCommand` in `BaseEntity`
- update entity imports to use the corrected type name

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840970fd30c8327998542c236f3e474