### PR TITLE
Refactor password auth client endpoint

### DIFF
--- a/packages/client/src/entities/session/api.ts
+++ b/packages/client/src/entities/session/api.ts
@@ -5,24 +5,26 @@ import { TokenRegisterDto } from '@rateme/core/domain/dtos/token-auth/token-regi
 
 import { ratemeApi } from '@/shared/api';
 
-export const tokenAuthApi = {
+export const passwordAuthApi = {
   login: reatomAsync(async (ctx, data: TokenLoginDto) => {
-    return ratemeApi.auth.token.login(data, { signal: ctx.controller.signal });
-  }, 'tokenAuthApi.login').pipe(withAbort()),
-
-  register: reatomAsync(async (ctx, data: TokenRegisterDto) => {
-    return ratemeApi.auth.token.register(data, {
+    return ratemeApi.auth.password.login(data, {
       signal: ctx.controller.signal,
     });
-  }, 'tokenAuthApi.register').pipe(withAbort()),
+  }, 'passwordAuthApi.login').pipe(withAbort()),
+
+  register: reatomAsync(async (ctx, data: TokenRegisterDto) => {
+    return ratemeApi.auth.password.register(data, {
+      signal: ctx.controller.signal,
+    });
+  }, 'passwordAuthApi.register').pipe(withAbort()),
 
   refresh: reatomAsync(async (ctx) => {
-    return ratemeApi.auth.token.refresh({ signal: ctx.controller.signal });
-  }, 'tokenAuthApi.refresh').pipe(withAbort()),
+    return ratemeApi.auth.password.refresh({ signal: ctx.controller.signal });
+  }, 'passwordAuthApi.refresh').pipe(withAbort()),
 
   logout: reatomAsync(async (ctx) => {
-    return ratemeApi.auth.token.logout({ signal: ctx.controller.signal });
-  }, 'tokenAuthApi.logout'),
+    return ratemeApi.auth.password.logout({ signal: ctx.controller.signal });
+  }, 'passwordAuthApi.logout'),
 };
 
 export const sessionApi = {

--- a/packages/client/src/entities/session/model.ts
+++ b/packages/client/src/entities/session/model.ts
@@ -13,7 +13,7 @@ import { LogoUrlVo } from '@rateme/core/domain/value-objects/logo-url.vo';
 import { NameVo } from '@rateme/core/domain/value-objects/name.vo';
 import { UsernameVo } from '@rateme/core/domain/value-objects/username.vo';
 
-import { sessionApi, tokenAuthApi } from './api.ts';
+import { passwordAuthApi, sessionApi } from './api.ts';
 
 export const $safeSession = atom<SessionEntity | null>(null, '$safeSession');
 
@@ -29,9 +29,9 @@ export const $session = atom((ctx) => {
 
 export const loginAction = reatomAsync(async (ctx, command: LoginCommand) => {
   switch (command.type) {
-    case 'token': {
+    case 'password': {
       const result = await ctx.schedule(() =>
-        tokenAuthApi.login(ctx, command.dto),
+        passwordAuthApi.login(ctx, command.dto),
       );
 
       if (result.data) {
@@ -44,16 +44,16 @@ export const loginAction = reatomAsync(async (ctx, command: LoginCommand) => {
 }, 'loginAction');
 
 export type LoginCommand = {
-  type: 'token';
+  type: 'password';
   dto: TokenLoginDto;
 };
 
 export const registerAction = reatomAsync(
   async (ctx, command: RegisterCommand) => {
     switch (command.type) {
-      case 'token': {
+      case 'password': {
         const result = await ctx.schedule(() =>
-          tokenAuthApi.register(ctx, command.dto),
+          passwordAuthApi.register(ctx, command.dto),
         );
 
         if (result.data) {
@@ -68,7 +68,7 @@ export const registerAction = reatomAsync(
 );
 
 export type RegisterCommand = {
-  type: 'token';
+  type: 'password';
   dto: TokenRegisterDto;
 };
 
@@ -84,7 +84,7 @@ export const loadMeAction = reatomAsync(async (ctx) => {
   }
 
   const tokenRefreshResult = await ctx.schedule((ctx) =>
-    tokenAuthApi.refresh(ctx),
+    passwordAuthApi.refresh(ctx),
   );
 
   if (tokenRefreshResult.data) {
@@ -101,7 +101,7 @@ export const loadMeAction = reatomAsync(async (ctx) => {
 export const logoutAction = action(async (ctx) => {
   document.cookie = '';
 
-  await ctx.schedule((ctx) => tokenAuthApi.logout(ctx));
+  await ctx.schedule((ctx) => passwordAuthApi.logout(ctx));
 
   await ctx.schedule((ctx) => {
     $safeSession(ctx, null);

--- a/packages/client/src/features/login-dialog/model.ts
+++ b/packages/client/src/features/login-dialog/model.ts
@@ -33,7 +33,7 @@ export const loginForm = formAtom({
   onSubmit: action(async (ctx, { email, password }) => {
     const result = await ctx.schedule((ctx) =>
       loginAction(ctx, {
-        type: 'token',
+        type: 'password',
         dto: { email: email.trim(), password },
       }),
     );

--- a/packages/core/src/api/endpoints/auth/auth.endpoint.ts
+++ b/packages/core/src/api/endpoints/auth/auth.endpoint.ts
@@ -1,13 +1,13 @@
 import { Endpoint, EndpointConfig } from '@/api/common/endpoint';
 
-import { TokenAuthEndpoint } from './token-auth.endpoint';
+import { PasswordAuthEndpoint } from './password-auth.endpoint';
 
 export class AuthEndpoint extends Endpoint {
-  readonly token: TokenAuthEndpoint;
+  readonly password: PasswordAuthEndpoint;
 
   constructor(config: EndpointConfig) {
     super(config);
 
-    this.token = new TokenAuthEndpoint(config);
+    this.password = new PasswordAuthEndpoint(config);
   }
 }

--- a/packages/core/src/api/endpoints/auth/password-auth.endpoint.ts
+++ b/packages/core/src/api/endpoints/auth/password-auth.endpoint.ts
@@ -9,11 +9,11 @@ import {
   TokenRegisterDtoSchema,
 } from '@/domain/dtos/token-auth/token-register.dto';
 
-export class TokenAuthEndpoint extends Endpoint {
+export class PasswordAuthEndpoint extends Endpoint {
   async login(dto: TokenLoginDto, options: EndpointMethodOptions) {
     TokenLoginDtoSchema.parse(dto);
 
-    return this.httpService.post<SessionResponseDto>('/auth/token/login', {
+    return this.httpService.post<SessionResponseDto>('/auth/password/login', {
       data: dto,
       signal: options.signal,
     });
@@ -22,20 +22,23 @@ export class TokenAuthEndpoint extends Endpoint {
   async register(dto: TokenRegisterDto, options: EndpointMethodOptions) {
     TokenRegisterDtoSchema.parse(dto);
 
-    return this.httpService.post<SessionResponseDto>('/auth/token/register', {
-      data: dto,
-      signal: options.signal,
-    });
+    return this.httpService.post<SessionResponseDto>(
+      '/auth/password/register',
+      {
+        data: dto,
+        signal: options.signal,
+      },
+    );
   }
 
   async refresh(options: EndpointMethodOptions) {
-    return this.httpService.post<SessionResponseDto>('/auth/token/refresh', {
+    return this.httpService.post<SessionResponseDto>('/auth/password/refresh', {
       signal: options.signal,
     });
   }
 
   async logout(options: EndpointMethodOptions) {
-    return this.httpService.post<void>('/auth/token/logout', {
+    return this.httpService.post<void>('/auth/password/logout', {
       signal: options.signal,
     });
   }


### PR DESCRIPTION
## Summary
- rename token auth endpoint to password auth
- switch auth endpoint to expose PasswordAuthEndpoint
- update session API/model to use password auth calls

## Testing
- `pnpm -r lint`
- `pnpm -r lint:fix`
- `pnpm -r test` *(fails: @rateme/core test script exits with error)*

------
https://chatgpt.com/codex/tasks/task_e_6840b1b97d308327851729fad35f79e0