### PR TITLE
Set sameSite on auth cookies

### DIFF
--- a/packages/server/src/core/modules/cookie/cookie.service.ts
+++ b/packages/server/src/core/modules/cookie/cookie.service.ts
@@ -28,11 +28,16 @@ export class CookieService {
     response.cookie(ACCESS_TOKEN_COOKIE_NAME, token, {
       httpOnly: true,
       secure: !this.configService.isDevelopment,
+      sameSite: 'lax',
     });
   }
 
   clearAccessToken(response: Response) {
-    response.clearCookie(ACCESS_TOKEN_COOKIE_NAME);
+    response.clearCookie(ACCESS_TOKEN_COOKIE_NAME, {
+      httpOnly: true,
+      secure: !this.configService.isDevelopment,
+      sameSite: 'lax',
+    });
   }
 
   getRefreshToken(request: Request) {
@@ -49,11 +54,16 @@ export class CookieService {
     response.cookie(REFRESH_TOKEN_COOKIE_NAME, token, {
       httpOnly: true,
       secure: !this.configService.isDevelopment,
+      sameSite: 'lax',
     });
   }
 
   clearRefreshToken(response: Response) {
-    response.clearCookie(REFRESH_TOKEN_COOKIE_NAME);
+    response.clearCookie(REFRESH_TOKEN_COOKIE_NAME, {
+      httpOnly: true,
+      secure: !this.configService.isDevelopment,
+      sameSite: 'lax',
+    });
   }
 
   getSessionId(request: Request) {
@@ -70,10 +80,15 @@ export class CookieService {
     response.cookie(SESSION_COOKIE_NAME, sessionId, {
       httpOnly: true,
       secure: !this.configService.isDevelopment,
+      sameSite: 'lax',
     });
   }
 
   clearSessionId(response: Response) {
-    response.clearCookie(SESSION_COOKIE_NAME);
+    response.clearCookie(SESSION_COOKIE_NAME, {
+      httpOnly: true,
+      secure: !this.configService.isDevelopment,
+      sameSite: 'lax',
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add `sameSite: 'lax'` to auth cookie options
- match options when clearing cookies

## Testing
- `pnpm --filter @rateme/server exec jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6840ca878f748327979279eae3294fe5