### PR TITLE
Add throttling to server auth actions

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,6 +31,7 @@
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^10.0.2",
     "ajv": "^8.17.1",
     "argon2": "^0.41.1",

--- a/packages/server/src/aggregates/password-auth/presentation/password-auth.controller.ts
+++ b/packages/server/src/aggregates/password-auth/presentation/password-auth.controller.ts
@@ -12,6 +12,7 @@ import {
   UseGuards,
   UsePipes,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { Request, Response } from 'express';
 
 import { SessionDtoService } from '@rateme/core/domain/dtos/entities/session.dto';
@@ -42,6 +43,7 @@ export class PasswordAuthController {
   ) {}
 
   @UsePipes(new ZodValidationPipe(TokenLoginDtoSchema))
+  @Throttle(5, 60)
   @Post('/login')
   async login(
     @Res({ passthrough: true }) response: Response,
@@ -68,6 +70,7 @@ export class PasswordAuthController {
   }
 
   @UsePipes(new ZodValidationPipe(TokenRegisterDtoSchema))
+  @Throttle(5, 60)
   @Post('/register')
   async register(
     @Res({ passthrough: true }) response: Response,
@@ -96,6 +99,7 @@ export class PasswordAuthController {
     };
   }
 
+  @Throttle(5, 60)
   @Post('/refresh')
   async refresh(
     @Req() request: Request,
@@ -125,6 +129,7 @@ export class PasswordAuthController {
   }
 
   @UseGuards(AuthGuard)
+  @Throttle(5, 60)
   @Post('/logout')
   async logout(
     @Req() request: Request,

--- a/packages/server/src/app/app.module.ts
+++ b/packages/server/src/app/app.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 
 import { CollectionModule } from '@/aggregates/collection/infrastructure';
 import { PasswordAuthModule } from '@/aggregates/password-auth/infrastructure';
@@ -14,6 +16,10 @@ import { JsonSchemaModule } from '@/core/modules/json-schema';
 
 @Module({
   imports: [
+    ThrottlerModule.forRoot({
+      ttl: 60,
+      limit: 5,
+    }),
     // auth
     AuthModule,
     PasswordAuthModule,
@@ -28,6 +34,12 @@ import { JsonSchemaModule } from '@/core/modules/json-schema';
     CollectionModule,
     RatingSystemModule,
     SessionModule,
+  ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^10.0.0
         version: 10.4.15(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)
+      '@nestjs/throttler':
+        specifier: ^6.4.0
+        version: 6.4.0(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^10.0.2
         version: 10.0.2(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(pg@8.13.1)(ts-node@10.9.2(@types/node@20.17.16)(typescript@5.7.3)))
@@ -1818,6 +1821,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.4.0':
+    resolution: {integrity: sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@nestjs/typeorm@10.0.2':
     resolution: {integrity: sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==}
@@ -5330,6 +5340,7 @@ packages:
   multer@1.4.4-lts.1:
     resolution: {integrity: sha512-WeSGziVj6+Z2/MwQo3GvqzgR+9Uc+qt8SwHKh3gvNPiISKfsMfG4SvCOFYlxxgkXt7yIV2i1yczehm0EOKIxIg==}
     engines: {node: '>= 6.0.0'}
+    deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
 
   multimatch@5.0.0:
     resolution: {integrity: sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==}
@@ -5384,6 +5395,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
@@ -8809,6 +8821,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-express': 10.4.15(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)
+
+  '@nestjs/throttler@6.4.0(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 10.4.15(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.15)(encoding@0.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      reflect-metadata: 0.2.2
 
   '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(pg@8.13.1)(ts-node@10.9.2(@types/node@20.17.16)(typescript@5.7.3)))':
     dependencies:


### PR DESCRIPTION
## Summary
- install `@nestjs/throttler`
- configure `ThrottlerModule` globally in the server
- rate limit login, register, refresh and logout endpoints

## Testing
- `pnpm -r lint`
- `pnpm --filter @rateme/server test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6840caa0788c8327a80fbdfd239ae4f8