### PR TITLE
Store hashed tokens

### DIFF
--- a/packages/server/src/aggregates/password-auth/infrastructure/password-auth.service.ts
+++ b/packages/server/src/aggregates/password-auth/infrastructure/password-auth.service.ts
@@ -171,13 +171,8 @@ export class PasswordAuthService extends PasswordAuthAbstractService {
         throw new BadRequestException(tokenNotFoundError);
       }
 
-      if (
-        command.refreshToken !==
-        this.cryptoService.decrypt(
-          token.refreshToken,
-          this.configService.auth.encryptionKey,
-        )
-      ) {
+      const hashed = await this.cryptoService.hash(command.refreshToken, true);
+      if (hashed !== token.refreshToken) {
         throw new BadRequestException(invalidTokenError);
       }
 
@@ -206,12 +201,8 @@ export class PasswordAuthService extends PasswordAuthAbstractService {
         throw new BadRequestException(tokenNotFoundError);
       }
 
-      const decrypted = this.cryptoService.decrypt(
-        token.accessToken,
-        this.configService.auth.encryptionKey,
-      );
-
-      if (command.accessToken !== decrypted) {
+      const hashed = await this.cryptoService.hash(command.accessToken, true);
+      if (hashed !== token.accessToken) {
         throw new BadRequestException(invalidTokenError);
       }
 
@@ -255,14 +246,8 @@ export class PasswordAuthService extends PasswordAuthAbstractService {
     const refreshToken = this.cryptoService.generateHash();
 
     const tokenEntity = TokenEntity.create({
-      accessToken: this.cryptoService.encrypt(
-        accessToken,
-        this.configService.auth.encryptionKey,
-      ),
-      refreshToken: this.cryptoService.encrypt(
-        refreshToken,
-        this.configService.auth.encryptionKey,
-      ),
+      accessToken: await this.cryptoService.hash(accessToken, true),
+      refreshToken: await this.cryptoService.hash(refreshToken, true),
       session: command.session,
       accessTokenExpiresAt: this.dateService.addMinutes(
         new Date(),

--- a/packages/server/src/aggregates/session/infrastructure/repositories/token.repository.ts
+++ b/packages/server/src/aggregates/session/infrastructure/repositories/token.repository.ts
@@ -4,6 +4,7 @@ import { TokenEntity } from '@rateme/core/domain/entities/session.entity';
 
 import { TokenAbstractRepository } from '@/aggregates/session/domain';
 import { SessionRepository } from '@/entities/session/infrastructure';
+import { CryptoService } from '@/core/modules/crypto';
 
 import { TokenRepositoryEntity } from '../entities';
 
@@ -13,6 +14,7 @@ export class TokenRepository extends TokenAbstractRepository {
   constructor(
     private readonly entityManager: EntityManager,
     private readonly sessionRepository: SessionRepository,
+    private readonly cryptoService: CryptoService,
   ) {
     super();
 
@@ -20,8 +22,9 @@ export class TokenRepository extends TokenAbstractRepository {
   }
 
   async findByAccessToken(token: string): Promise<TokenEntity | null> {
+    const hashed = await this.cryptoService.hash(token, true);
     const tokenEntity = await this.tokenEntity.findOne({
-      where: { accessToken: token },
+      where: { accessToken: hashed },
       relations: ['session', 'session.user'],
     });
 
@@ -70,8 +73,9 @@ export class TokenRepository extends TokenAbstractRepository {
   }
 
   async findByRefreshToken(token: string): Promise<TokenEntity | null> {
+    const hashed = await this.cryptoService.hash(token, true);
     const tokenEntity = await this.tokenEntity.findOne({
-      where: { refreshToken: token },
+      where: { refreshToken: hashed },
       relations: ['session', 'session.user'],
     });
 

--- a/packages/server/src/aggregates/session/infrastructure/session.unit-of-work.ts
+++ b/packages/server/src/aggregates/session/infrastructure/session.unit-of-work.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { DataSource, EntityManager } from 'typeorm';
 
 import { TypeormUnitOfWork } from '@/core/unit-of-work';
@@ -6,6 +6,7 @@ import { SessionAbstractRepository } from '@/entities/session/domain';
 import { SessionRepository } from '@/entities/session/infrastructure';
 import { UserAbstractRepository } from '@/entities/user/domain';
 import { UserRepository } from '@/entities/user/infrastructure';
+import { CryptoService } from '@/core/modules/crypto';
 
 import { TokenAbstractRepository } from '../domain';
 import { TokenRepository } from './repositories';
@@ -18,7 +19,10 @@ export interface SessionUnitOfWorkContext {
 
 @Injectable()
 export class SessionUnitOfWork extends TypeormUnitOfWork<SessionUnitOfWorkContext> {
-  constructor(dataSource: DataSource) {
+  constructor(
+    dataSource: DataSource,
+    @Inject(CryptoService) private readonly cryptoService: CryptoService,
+  ) {
     super(dataSource);
   }
 
@@ -31,6 +35,7 @@ export class SessionUnitOfWork extends TypeormUnitOfWork<SessionUnitOfWorkContex
     const tokenRepository = new TokenRepository(
       entityManager,
       sessionRepository,
+      this.cryptoService,
     );
 
     return {

--- a/packages/server/src/core/modules/crypto/crypto.service.ts
+++ b/packages/server/src/core/modules/crypto/crypto.service.ts
@@ -4,6 +4,7 @@ import {
   createCipheriv,
   createDecipheriv,
   createHash,
+  createHmac,
   randomBytes,
 } from 'crypto';
 
@@ -15,7 +16,15 @@ const IV_LENGTH = 16;
 export class CryptoService {
   constructor(private readonly configService: ConfigService) {}
 
-  hash(source: string) {
+  hash(source: string, deterministic = false) {
+    if (deterministic) {
+      return Promise.resolve(
+        createHmac('sha256', this.configService.auth.encryptionKey)
+          .update(source)
+          .digest('hex'),
+      );
+    }
+
     return argon2.hash(source);
   }
 


### PR DESCRIPTION
## Summary
- store hashed session tokens instead of encrypted tokens
- hash incoming tokens before performing lookups
- pass CryptoService into SessionUnitOfWork
- reuse `CryptoService.hash` for token hashing

## Testing
- `pnpm --filter ./packages/server test` *(fails: No tests found)*
- `pnpm --filter ./packages/client exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6840ca9b9f988327a576b25b1ea10878