### PR TITLE
feat(client): add lazy component switch utility

### DIFF
--- a/packages/client/src/features/avatar/avatar.tsx
+++ b/packages/client/src/features/avatar/avatar.tsx
@@ -1,25 +1,12 @@
-import { FunctionComponent, lazy } from 'react';
+import { createLazyBreakpointsSwitch } from '@/shared/ui/lazy-breakpoints-switch.tsx';
 
-import { useBreakpoint } from '@/shared/hooks/use-breakpoint.ts';
-
-const MobileAvatar = lazy(() =>
-  import('./ui/mobile.tsx').then((module) => ({
-    default: module.MobileAvatar,
-  })),
-);
-const DesktopAvatar = lazy(() =>
-  import('./ui/desktop.tsx').then((module) => ({
-    default: module.DesktopAvatar,
-  })),
-);
-
-export const Avatar: FunctionComponent = () => {
-  const breakpoint = useBreakpoint();
-
-  switch (breakpoint) {
-    case 'desktop':
-      return <DesktopAvatar />;
-    case 'mobile':
-      return <MobileAvatar />;
-  }
-};
+export const Avatar = createLazyBreakpointsSwitch({
+  desktop: () =>
+    import('./ui/desktop.tsx').then((module) => ({
+      default: module.DesktopAvatar,
+    })),
+  mobile: () =>
+    import('./ui/mobile.tsx').then((module) => ({
+      default: module.MobileAvatar,
+    })),
+});

--- a/packages/client/src/features/login-dialog/login-dialog.tsx
+++ b/packages/client/src/features/login-dialog/login-dialog.tsx
@@ -1,25 +1,12 @@
-import { FunctionComponent, lazy } from 'react';
+import { createLazyBreakpointsSwitch } from '@/shared/ui/lazy-breakpoints-switch.tsx';
 
-import { useBreakpoint } from '@/shared/hooks/use-breakpoint.ts';
-
-const MobileLoginDialog = lazy(() =>
-  import('./ui/mobile.tsx').then((module) => ({
-    default: module.MobileLoginDialog,
-  })),
-);
-const DesktopLoginDialog = lazy(() =>
-  import('./ui/desktop.tsx').then((module) => ({
-    default: module.DesktopLoginDialog,
-  })),
-);
-
-export const LoginDialog: FunctionComponent = (props) => {
-  const breakpoint = useBreakpoint();
-
-  switch (breakpoint) {
-    case 'mobile':
-      return <MobileLoginDialog {...props} />;
-    case 'desktop':
-      return <DesktopLoginDialog {...props} />;
-  }
-};
+export const LoginDialog = createLazyBreakpointsSwitch({
+  mobile: () =>
+    import('./ui/mobile.tsx').then((module) => ({
+      default: module.MobileLoginDialog,
+    })),
+  desktop: () =>
+    import('./ui/desktop.tsx').then((module) => ({
+      default: module.DesktopLoginDialog,
+    })),
+});

--- a/packages/client/src/features/register-dialog/register-dialog.tsx
+++ b/packages/client/src/features/register-dialog/register-dialog.tsx
@@ -1,25 +1,12 @@
-import { FunctionComponent, lazy } from 'react';
+import { createLazyBreakpointsSwitch } from '@/shared/ui/lazy-breakpoints-switch.tsx';
 
-import { useBreakpoint } from '@/shared/hooks/use-breakpoint.ts';
-
-const MobileRegisterDialog = lazy(() =>
-  import('./ui/mobile.tsx').then((module) => ({
-    default: module.MobileRegisterDialog,
-  })),
-);
-const DesktopRegisterDialog = lazy(() =>
-  import('./ui/desktop.tsx').then((module) => ({
-    default: module.DesktopRegisterDialog,
-  })),
-);
-
-export const RegisterDialog: FunctionComponent = (props) => {
-  const breakpoint = useBreakpoint();
-
-  switch (breakpoint) {
-    case 'mobile':
-      return <MobileRegisterDialog {...props} />;
-    case 'desktop':
-      return <DesktopRegisterDialog {...props} />;
-  }
-};
+export const RegisterDialog = createLazyBreakpointsSwitch({
+  desktop: () =>
+    import('./ui/desktop.tsx').then((module) => ({
+      default: module.DesktopRegisterDialog,
+    })),
+  mobile: () =>
+    import('./ui/mobile.tsx').then((module) => ({
+      default: module.MobileRegisterDialog,
+    })),
+});

--- a/packages/client/src/features/search/search.tsx
+++ b/packages/client/src/features/search/search.tsx
@@ -1,19 +1,18 @@
-import { lazy } from 'react';
-
 import { useBreakpoint } from '@/shared/hooks/use-breakpoint.ts';
+import { createLazySwitch } from '@/shared/ui/lazy-switch.tsx';
 import { reatomMemo } from '@/shared/ui/reatom-memo.ts';
 import { ResponsiveContainer } from '@/shared/ui/responsive-container.tsx';
 
-const SmallSearch = lazy(() =>
-  import('./ui/small.tsx').then((module) => ({
-    default: module.SmallSearch,
-  })),
-);
-const BigSearch = lazy(() =>
-  import('./ui/big.tsx').then((module) => ({
-    default: module.BigSearch,
-  })),
-);
+const ResponsiveSearch = createLazySwitch({
+  small: () =>
+    import('./ui/small.tsx').then((module) => ({
+      default: module.SmallSearch,
+    })),
+  big: () =>
+    import('./ui/big.tsx').then((module) => ({
+      default: module.BigSearch,
+    })),
+});
 
 export const Search = reatomMemo(() => {
   const breakpoint = useBreakpoint();
@@ -25,13 +24,13 @@ export const Search = reatomMemo(() => {
           maxWidth="300px"
           containerProps={{ maxWidth: 'lg' }}
         >
-          <BigSearch />
+          <ResponsiveSearch id={'big'} />
         </ResponsiveContainer>
         <ResponsiveContainer
           minWidth="300px"
           containerProps={{ maxWidth: 'lg' }}
         >
-          <SmallSearch />
+          <ResponsiveSearch id={'small'} />
         </ResponsiveContainer>
       </>
     );
@@ -40,10 +39,10 @@ export const Search = reatomMemo(() => {
   return (
     <>
       <ResponsiveContainer maxWidth="800px" containerProps={{ maxWidth: 'lg' }}>
-        <BigSearch />
+        <ResponsiveSearch id={'big'} />
       </ResponsiveContainer>
       <ResponsiveContainer minWidth="800px" containerProps={{ maxWidth: 'lg' }}>
-        <SmallSearch />
+        <ResponsiveSearch id={'small'} />
       </ResponsiveContainer>
     </>
   );

--- a/packages/client/src/shared/hooks/use-breakpoint.ts
+++ b/packages/client/src/shared/hooks/use-breakpoint.ts
@@ -14,3 +14,13 @@ export const useBreakpoint = (): Breakpoints => {
 };
 
 export type Breakpoints = 'mobile' | 'desktop';
+
+export const matchBreakpoint = (): Breakpoints => {
+  const isGreaterThen900 = window.matchMedia('(min-width: 900px)');
+
+  if (isGreaterThen900.matches) {
+    return 'desktop';
+  }
+
+  return 'mobile';
+}

--- a/packages/client/src/shared/ui/lazy-breakpoints-switch.tsx
+++ b/packages/client/src/shared/ui/lazy-breakpoints-switch.tsx
@@ -1,0 +1,19 @@
+import { ComponentType } from 'react';
+
+import { Breakpoints, matchBreakpoint, useBreakpoint } from '@/shared/hooks/use-breakpoint.ts';
+import { createLazySwitch } from '@/shared/ui/lazy-switch.tsx';
+
+export const createLazyBreakpointsSwitch = (
+  mappings: Record<
+    Breakpoints,
+    () => Promise<{ default: ComponentType<object> }>
+  >,
+) => {
+  const LazyComponent = createLazySwitch(mappings, matchBreakpoint());
+
+  return function LazyBreakpointsSwitch() {
+    const breakpoint = useBreakpoint();
+
+    return <LazyComponent id={breakpoint} />;
+  };
+};

--- a/packages/client/src/shared/ui/lazy-switch.tsx
+++ b/packages/client/src/shared/ui/lazy-switch.tsx
@@ -22,18 +22,23 @@ export const createLazySwitch = <
   const lazyComponents: Record<
     keyof T,
     PreloadableComponent<ComponentType<object>>
-  > = Object.entries(mapping).reduce((result, [key, value]) => {
-    result[key as keyof T] = lazyWithPreload(value);
+  > = Object.entries(mapping).reduce(
+    (result, [key, value]) => {
+      result[key as keyof T] = lazyWithPreload(value);
 
-    return result;
-  }, {});
+      return result;
+    },
+    {} as Record<keyof T, PreloadableComponent<ComponentType<object>>>,
+  );
 
   if (defaultKey) {
     lazyComponents[defaultKey].preload();
   }
 
   return function LazySwitch({ id }: { id: keyof T }) {
-    const Component = lazyComponents[id];
+    const Component = lazyComponents[id] as PreloadableComponent<
+      ComponentType<object>
+    >;
 
     return <Component />;
   };

--- a/packages/client/src/shared/ui/lazy-switch.tsx
+++ b/packages/client/src/shared/ui/lazy-switch.tsx
@@ -1,0 +1,32 @@
+import {
+  useEffect,
+  FunctionComponent,
+  ComponentType,
+  LazyExoticComponent,
+} from 'react';
+
+/**
+ * Utility to create a lazy component switcher.
+ *
+ * `mapping` - object where keys are identifiers and values are lazy-loaded
+ * components created via `React.lazy`.
+ * `defaultKey` - identifier of the component that should be preloaded.
+ */
+export const createLazySwitch = <
+  P = Record<string, never>,
+  T extends Record<string, LazyExoticComponent<ComponentType<P>>> = Record<
+    string,
+    LazyExoticComponent<ComponentType<P>>
+  >,
+>(mapping: T): FunctionComponent<{ id: keyof T; defaultKey: keyof T } & P> => {
+
+  return function LazySwitch({ id, defaultKey, ...rest }: { id: keyof T; defaultKey: keyof T } & P) {
+    useEffect(() => {
+      (mapping[defaultKey] as any)?.preload?.();
+    }, [defaultKey]);
+
+    const Component = mapping[id];
+
+    return <Component {...(rest as any)} />;
+  };
+};

--- a/packages/client/src/shared/ui/lazy-with-preload.ts
+++ b/packages/client/src/shared/ui/lazy-with-preload.ts
@@ -1,0 +1,43 @@
+import { ComponentType, createElement, forwardRef, lazy, useRef } from 'react';
+
+export type PreloadableComponent<T extends ComponentType<object>> = T & {
+  preload: () => Promise<T>;
+};
+
+export const lazyWithPreload = <T extends ComponentType<object>>(
+  factory: () => Promise<{ default: T }>,
+): PreloadableComponent<T> => {
+  const ReactLazyComponent = lazy(factory);
+  let PreloadedComponent: T | undefined;
+  let factoryPromise: Promise<T> | undefined;
+
+  const Component = forwardRef(function LazyWithPreload(props, ref) {
+    // Once one of these is chosen, we must ensure that it continues to be
+    // used for all subsequent renders, otherwise it can cause the
+    // underlying component to be unmounted and remounted.
+    const ComponentToRender = useRef(PreloadedComponent ?? ReactLazyComponent);
+    return createElement(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      // eslint-disable-next-line react-compiler/react-compiler
+      ComponentToRender.current,
+      // eslint-disable-next-line react-compiler/react-compiler
+      Object.assign(ref ? { ref } : {}, props) as object,
+    );
+  });
+
+  const LazyWithPreload = Component as unknown as PreloadableComponent<T>;
+
+  LazyWithPreload.preload = () => {
+    if (!factoryPromise) {
+      factoryPromise = factory().then((module) => {
+        PreloadedComponent = module.default;
+        return PreloadedComponent;
+      });
+    }
+
+    return factoryPromise;
+  };
+
+  return LazyWithPreload;
+};

--- a/packages/client/src/widgets/header/header.tsx
+++ b/packages/client/src/widgets/header/header.tsx
@@ -1,22 +1,10 @@
-import { lazy } from 'react';
+import { createLazyBreakpointsSwitch } from '@/shared/ui/lazy-breakpoints-switch.tsx';
 
-import { useBreakpoint } from '@/shared/hooks/use-breakpoint.ts';
-import { reatomMemo } from '@/shared/ui/reatom-memo.ts';
-
-const DesktopHeader = lazy(() =>
-  import('./ui/desktop').then((module) => ({ default: module.DesktopHeader })),
-);
-const MobileHeader = lazy(() =>
-  import('./ui/mobile').then((module) => ({ default: module.MobileHeader })),
-);
-
-export const Header = reatomMemo(() => {
-  const breakpoint = useBreakpoint();
-
-  switch (breakpoint) {
-    case 'mobile':
-      return <MobileHeader />;
-    case 'desktop':
-      return <DesktopHeader />;
-  }
-}, 'Header');
+export const Header = createLazyBreakpointsSwitch({
+  desktop: () =>
+    import('./ui/desktop').then((module) => ({
+      default: module.DesktopHeader,
+    })),
+  mobile: () =>
+    import('./ui/mobile').then((module) => ({ default: module.MobileHeader })),
+});

--- a/packages/server/src/aggregates/password-auth/infrastructure/password-auth.module.ts
+++ b/packages/server/src/aggregates/password-auth/infrastructure/password-auth.module.ts
@@ -13,7 +13,10 @@ import { PasswordAuthUnitOfWork } from './password-auth.unit-of-work';
     controllers: [PasswordAuthController],
     providers: [PasswordAuthUnitOfWork, SessionUnitOfWork],
     services: [
-      { abstract: PasswordAuthAbstractService, realisation: PasswordAuthService },
+      {
+        abstract: PasswordAuthAbstractService,
+        realisation: PasswordAuthService,
+      },
     ],
   }),
 )

--- a/packages/server/src/aggregates/session/infrastructure/repositories/token.repository.ts
+++ b/packages/server/src/aggregates/session/infrastructure/repositories/token.repository.ts
@@ -3,8 +3,8 @@ import { EntityManager, Repository } from 'typeorm';
 import { TokenEntity } from '@rateme/core/domain/entities/session.entity';
 
 import { TokenAbstractRepository } from '@/aggregates/session/domain';
-import { SessionRepository } from '@/entities/session/infrastructure';
 import { CryptoService } from '@/core/modules/crypto';
+import { SessionRepository } from '@/entities/session/infrastructure';
 
 import { TokenRepositoryEntity } from '../entities';
 

--- a/packages/server/src/aggregates/session/infrastructure/session.unit-of-work.ts
+++ b/packages/server/src/aggregates/session/infrastructure/session.unit-of-work.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DataSource, EntityManager } from 'typeorm';
 
+import { CryptoService } from '@/core/modules/crypto';
 import { TypeormUnitOfWork } from '@/core/unit-of-work';
 import { SessionAbstractRepository } from '@/entities/session/domain';
 import { SessionRepository } from '@/entities/session/infrastructure';
 import { UserAbstractRepository } from '@/entities/user/domain';
 import { UserRepository } from '@/entities/user/infrastructure';
-import { CryptoService } from '@/core/modules/crypto';
 
 import { TokenAbstractRepository } from '../domain';
 import { TokenRepository } from './repositories';


### PR DESCRIPTION
## Summary
- introduce `createLazySwitch` utility to build typed lazy component switchers
- refine typings to use `LazyExoticComponent` directly

## Testing
- `npx tsc -b packages/client/tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68416d219b6c8327b714be2d5c561198