### PR TITLE
docs: add server instructions

### DIFF
--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -1,0 +1,71 @@
+# Development Notes
+
+This package contains the NestJS API server. Below are commands useful for local development.
+
+## Database
+
+Start the PostgreSQL container defined in `docker-compose.yml` from the repository root:
+
+```bash
+pnpm run server:db
+```
+
+## Development
+
+Run the server in watch mode from within this package:
+
+```bash
+pnpm run start:dev
+```
+
+From the repository root you can use:
+
+```bash
+pnpm run server:start
+```
+
+## Building
+
+Create a production build:
+
+```bash
+pnpm run build
+```
+
+## Linting and Formatting
+
+- Lint the source code:
+  ```bash
+  pnpm run lint
+  ```
+- Automatically fix lint problems:
+  ```bash
+  pnpm run lint:fix
+  ```
+- Check formatting with Prettier:
+  ```bash
+  pnpm run format
+  ```
+- Format all files:
+  ```bash
+  pnpm run format:fix
+  ```
+
+## Tests
+
+- Unit tests:
+  ```bash
+  pnpm run test
+  ```
+- End-to-end tests:
+  ```bash
+  pnpm run test:e2e
+  ```
+- Coverage report:
+  ```bash
+  pnpm run test:cov
+  ```
+
+## Pre-push Hook
+
+A pre-push hook runs `pnpm run format:fix` and `pnpm run lint:fix` before pushing changes.


### PR DESCRIPTION
## Summary
- add AGENTS.md in packages/server with scripts for development

## Testing
- `pnpm run lint` in packages/server
- `pnpm run test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684189270e34832789890f4ea072281f