### PR TITLE
Add AGENTS instructions for core

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,0 +1,56 @@
+# Development Guide
+
+This file explains how to work with the **core** package.
+
+## Building
+
+Compile the TypeScript sources with:
+
+```bash
+pnpm run build
+```
+
+From the repository root you can run the same script via:
+
+```bash
+pnpm run core:build
+```
+
+The compiled files are written to the `dist` directory.
+
+## Watch mode
+
+During development you can watch and rebuild automatically:
+
+```bash
+pnpm run start
+```
+
+## Formatting and linting
+
+Check code formatting with:
+
+```bash
+pnpm run format
+```
+
+Fix formatting issues automatically with:
+
+```bash
+pnpm run format:fix
+```
+
+Run ESLint with:
+
+```bash
+pnpm run lint
+```
+
+## Pre-push hook
+
+Husky runs the `prepush` script before pushing. It formats the code and runs the linter:
+
+```bash
+pnpm run format && pnpm run lint
+```
+


### PR DESCRIPTION
## Summary
- document build, lint and format steps for the core package
- describe watch mode and Husky prepush hook

## Testing
- `pnpm --filter @rateme/core run format`
- `pnpm --filter @rateme/core run lint`
- `pnpm --filter @rateme/core run prepush`
- `pnpm --filter @rateme/server run test` *(fails: No tests found)*
- `pnpm --filter @rateme/client run test` *(fails: exited watch mode)*


------
https://chatgpt.com/codex/tasks/task_e_684189263f9c8327a4f3698b981e02d5